### PR TITLE
Fix auto-retry stopping permanently after limit and raise max to 50

### DIFF
--- a/Grok-Enhancer.user.js
+++ b/Grok-Enhancer.user.js
@@ -3510,7 +3510,17 @@
         const now = Date.now();
         if (now - _ge_imLastModScan < 400) return;
         _ge_imLastModScan = now;
-        if (!ge_findModerationSignal()) return;
+        if (!ge_findModerationSignal()) {
+            // Reset retry counter when moderation clears (new generation succeeded or
+            // user started fresh) so subsequent prompts can retry from zero again.
+            // Guard with a cooldown to avoid resetting during the brief gap between
+            // a retry click and the moderation signal reappearing.
+            if (ge_imRetryCount > 0 && now - ge_imLastRetryTime > 5000) {
+                ge_imRetryCount = 0;
+                ge_updateImStatus();
+            }
+            return;
+        }
 
         const btn = document.querySelector('button[aria-label="Make video"]')
             || document.querySelector('button[aria-label="Send"]')
@@ -4283,11 +4293,11 @@
         const retRow = document.createElement('div'); retRow.className = 'im-row';
         const retLbl = document.createElement('span'); retLbl.className = 'im-lbl'; retLbl.textContent = 'Max Retries';
         const retInp = document.createElement('input');
-        retInp.type = 'number'; retInp.min = '1'; retInp.max = '20'; retInp.value = ge_imMaxRetries;
+        retInp.type = 'number'; retInp.min = '1'; retInp.max = '50'; retInp.value = ge_imMaxRetries;
         retInp.style.cssText = 'width:42px;padding:2px 4px;background:#222;color:#fff;border:1px solid #444;border-radius:4px;font-size:11px;text-align:center;';
         retInp.addEventListener('change', () => {
             const v = parseInt(retInp.value);
-            if (v >= 1 && v <= 20) { ge_imMaxRetries = v; setState('GrokEnhancer_IM_MaxRetries', v); }
+            if (v >= 1 && v <= 50) { ge_imMaxRetries = v; setState('GrokEnhancer_IM_MaxRetries', v); }
         });
         retRow.appendChild(retLbl); retRow.appendChild(retInp);
         section.appendChild(retRow);


### PR DESCRIPTION
## Summary

Fixes #1 — two related problems with the auto-retry feature:

**Bug: retries stop working permanently after hitting the limit**

`ge_imRetryCount` is scoped to the script's closure and never reset after exhausting retries. Because Grok is a SPA, navigating away and back does not re-run the userscript, so the counter stays at the max for the entire browser session — explaining why a page refresh does nothing and only a full browser restart helps.

Fix: in `ge_checkModeration`, when `ge_findModerationSignal()` returns false (moderation has cleared — meaning a new generation succeeded or the user started fresh), reset `ge_imRetryCount` to 0 if it was non-zero and at least 5 seconds have passed since the last retry. The 5-second cooldown prevents the counter from resetting during the brief moment between a retry click and the moderation signal reappearing.

**Enhancement: raise Max Retries cap from 20 to 50**

The input's `max` attribute and the change-handler validation both capped the value at 20. Both updated to 50.

## Files changed

- `Grok-Enhancer.user.js` — reset logic in `ge_checkModeration`, input max raised to 50

## Test plan

- [ ] Hit the retry limit — retries should stop as before
- [ ] Submit a new prompt that generates successfully — status should reset to "Ready" and retries should work again on the next moderated response
- [ ] Set Max Retries to a value above 20 (e.g. 35) — it should save and be respected